### PR TITLE
Add build-system metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "pneumonia-xray-ai"
 version = "0.1.0"


### PR DESCRIPTION
# Pull Request

## Summary
Adds standard Python build-system metadata to `pyproject.toml` to improve packaging compliance and align the repository scaffold with modern Python project structure expectations.

## Changes Made
- Added `[build-system]` section
- Specified `setuptools>=61.0`
- Added `setuptools.build_meta` backend

## Why
This improves compatibility with Python packaging tools and makes the project scaffold more complete for future development and installation workflows.

Closes #20