### PR TITLE
Document explicit class imbalance ratios in dataset docs

### DIFF
--- a/docs/DATASET.md
+++ b/docs/DATASET.md
@@ -44,7 +44,16 @@ data/raw/chest_xray/
 ## Key Concerns
 
 ### Class Imbalance
-The training set has significantly more pneumonia samples than normal samples (~3:1 ratio). This must be addressed to avoid a model that is biased toward predicting pneumonia. Mitigation options include:
+The training set has significantly more pneumonia samples than normal samples (~3:1 ratio). This must be addressed to avoid a model that is biased toward predicting pneumonia.
+
+### Split Imbalance Ratios
+- **Train:** 3875 / 1341 ≈ **2.89:1**
+- **Validation:** 8 / 8 = **1:1**
+- **Test:** 390 / 234 ≈ **1.67:1**
+
+This confirms that the strongest class imbalance exists in the training split, where pneumonia samples are nearly 3 times more frequent than normal samples.
+
+Mitigation options include:
 - Weighted loss function
 - Oversampling / undersampling
 - Class-weighted metrics for evaluation


### PR DESCRIPTION
# Pull Request

## Summary
Adds explicit numerical class imbalance ratios for the train, validation, and test splits in `docs/DATASET.md`.

## Changes Made
- Added exact train split ratio
- Added validation split ratio
- Added test split ratio
- Clarified that the strongest imbalance is in training

## Why
This improves dataset documentation precision and satisfies the dataset contract issue requirements for documenting class imbalance properties.

Closes #26