### PR TITLE
Add pixel intensity distribution section to EDA notebook

### DIFF
--- a/notebooks/01_eda_chest_xray.ipynb
+++ b/notebooks/01_eda_chest_xray.ipynb
@@ -4,9 +4,7 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "gpuType": "T4",
-      "authorship_tag": "ABX9TyONASkP/BXhHgp3VR1p8x4q",
-      "include_colab_link": true
+      "gpuType": "T4"
     },
     "kernelspec": {
       "name": "python3",
@@ -14,20 +12,9 @@
     },
     "language_info": {
       "name": "python"
-    },
-    "accelerator": "GPU"
+    }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/atilimai/pneumonia-xray-ai/blob/main/notebooks/01_eda_chest_xray.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "source": [
@@ -57,7 +44,7 @@
       "metadata": {
         "id": "1ERcyweSJJdu"
       },
-      "execution_count": null,
+      "execution_count": 2,
       "outputs": []
     },
     {
@@ -88,10 +75,25 @@
         "    print(f\"- {split.upper()}: {total} images (Normal: {counts['NORMAL']}, Pneumonia: {counts['PNEUMONIA']})\")"
       ],
       "metadata": {
-        "id": "Roht2c-gSG37"
+        "id": "Roht2c-gSG37",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "80eb9075-18df-4064-c081-5d994a6c48a7"
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Dataset Split Verification:\n",
+            "- TRAIN: 0 images (Normal: 0, Pneumonia: 0)\n",
+            "- VAL: 0 images (Normal: 0, Pneumonia: 0)\n",
+            "- TEST: 0 images (Normal: 0, Pneumonia: 0)\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -115,10 +117,37 @@
         "plt.show()"
       ],
       "metadata": {
-        "id": "tZ_IQY_MSZW3"
+        "id": "tZ_IQY_MSZW3",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 575
+        },
+        "outputId": "ee543370-3c79-4099-c1a7-0c0803a77e5b"
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/tmp/ipykernel_1976/3314206940.py:4: FutureWarning: \n",
+            "\n",
+            "Passing `palette` without assigning `hue` is deprecated and will be removed in v0.14.0. Assign the `x` variable to `hue` and set `legend=False` for the same effect.\n",
+            "\n",
+            "  sns.barplot(x=classes, y=train_counts, palette=colors)\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 800x500 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAscAAAHDCAYAAADIj7elAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAP1FJREFUeJzt3Xt8z/X///H7e7Oj2cbM1moOObM5NGEIMeZQOSXnc6k+QsixIj4fhKjk9KkPiXLIIUX9MKdIC5lScowQZo6bNnZ8/f7w2vvbu23srR11u14u78vn836+ns/X+/F6297unj1fz7fFMAxDAAAAAOSQ3wUAAAAABQXhGAAAADARjgEAAAAT4RgAAAAwEY4BAAAAE+EYAAAAMBGOAQAAABPhGAAAADARjgEAAAAT4RhAgdK3b1+VLVv2nsa+8cYbslgsOVvQfervvM8FyY4dO2SxWLRjx45cf63Mfr4sFoteeumlXH9tSVq8eLEsFot+++23PHk94J+KcAwgWywWS7YeeRFSCqr169erSZMmKlWqlNzd3fXwww/rmWee0caNG+/pfFOmTNG6devsGhMXF6eJEyeqZs2a8vDwkJubm4KCgjR69GidP3/+nurIK7/99pvNz5KTk5NKliypBg0aaNy4cTpz5kyOvda9vLd5pSDXBvwTWAzDMPK7CAAF38cff2zzfMmSJYqIiNDSpUtt2lu0aCE/P797fp3k5GSlpaXJxcXF7rEpKSlKSUmRq6vrPb/+vXrrrbc0cuRINWnSRO3atZO7u7tOnDihLVu2qGbNmlq8eLHd5/Tw8NDTTz+d7bEnT55UWFiYzpw5o86dO6tRo0ZydnbWwYMHtXz5cpUoUULHjh2TdHvmeMeOHQVqFvK3335TuXLl1K1bN7Vp00ZpaWm6du2a9u3bp7Vr18pisWjhwoXq2rWrdUxaWpqSkpLk7OwsB4fsz/fY+95Kmf98WSwWDRo0SHPmzMn2ee61ttTUVCUnJ8vFxYX/QgLkoiL5XQCAwqFnz542z7/77jtFRERkaP+rhIQEubu7Z/t1nJyc7qk+SSpSpIiKFMn7j7WUlBT9+9//VosWLbR58+YMx2NiYvKkho4dO+rixYvasWOHGjVqZHN88uTJmjZtWq7XkRMeeeSRDD9Xp0+fVsuWLdWnTx9VrVpVNWvWlCQ5ODjk+j+G4uPjVbRo0Xz7+Urn6OgoR0fHfHt94J+CZRUAckzTpk0VFBSk/fv3q3HjxnJ3d9e4ceMkSZ9//rnatm2rgIAAubi4qHz58vr3v/+t1NRUm3P8dS1s+n9qf+utt/T++++rfPnycnFx0aOPPqp9+/bZjL3TmtB169YpKChILi4uql69eqZLHXbs2KE6derI1dVV5cuX13//+99srWO+fPmy4uLi1LBhw0yPlypVyuZ5YmKiJkyYoAoVKsjFxUWBgYEaNWqUEhMTbeqOj4/XRx99ZF1m0Ldv3yxrWLNmjX788Ue9+uqrGYKxJHl6emry5Ml3vI633npLDRo0kI+Pj9zc3BQSEqLVq1dn6BcREaFGjRrJ29tbHh4eqly5svXPOd17772n6tWry93dXcWLF1edOnW0bNmyO77+nZQpU0aLFy9WUlKSpk+fbm3PbM3x8ePH1alTJ/n7+8vV1VUPPfSQunbtqtjYWEl3fm/T/7x/+eUXde/eXcWLF7e+n3f6Wfjkk09UuXJlubq6KiQkRDt37rQ5ntUa77+e8061ZbXmeN68eapevbpcXFwUEBCgQYMG6fr16zZ90n83f/nlFz3++ONyd3fXgw8+aPNeAriNmWMAOerKlStq3bq1unbtqp49e1qXWCxevFgeHh4aPny4PDw8tG3bNo0fP15xcXGaMWPGXc+7bNky3bhxQ88//7wsFoumT5+ujh076uTJk3edbf7mm2+0du1a/etf/1KxYsU0e/ZsderUSWfOnJGPj48k6cCBA2rVqpUeeOABTZw4UampqZo0aZJ8fX3vWlupUqXk5uam9evXa/DgwSpRokSWfdPS0vTUU0/pm2++0cCBA1W1alX99NNPevvtt3Xs2DHrWtOlS5fq2WefVd26dTVw4EBJUvny5bM87xdffCFJ6tWr113rzcq7776rp556Sj169FBSUpJWrFihzp07a8OGDWrbtq0k6dChQ3riiSdUo0YNTZo0SS4uLjpx4oR2795tPc8HH3ygIUOG6Omnn9bQoUN169YtHTx4UHv27FH37t3vub7Q0FCVL19eERERWfZJSkpSeHi4EhMTNXjwYPn7++vcuXPasGGDrl+/Li8vr2y9t507d1bFihU1ZcoU3W314ddff62VK1dqyJAhcnFx0bx589SqVSvt3btXQUFBdl2jvX/ub7zxhiZOnKiwsDC9+OKLOnr0qObPn699+/Zp9+7dNr8b165dU6tWrdSxY0c988wzWr16tUaPHq3g4GC1bt3arjqB+5oBAPdg0KBBxl8/Qpo0aWJIMhYsWJChf0JCQoa2559/3nB3dzdu3bplbevTp49RpkwZ6/NTp04ZkgwfHx/j6tWr1vbPP//ckGSsX7/e2jZhwoQMNUkynJ2djRMnTljbfvzxR0OS8d5771nbnnzyScPd3d04d+6cte348eNGkSJFMpwzM+PHjzckGUWLFjVat25tTJ482di/f3+GfkuXLjUcHByMXbt22bQvWLDAkGTs3r3b2la0aFGjT58+d31twzCM2rVrG15eXtnqaxgZ32fDyPhnlJSUZAQFBRnNmjWztr399tuGJOPSpUtZnrtdu3ZG9erVs11LuvQ/6xkzZtzx3JKM2NhYwzAMY/v27YYkY/v27YZhGMaBAwcMScaqVavu+FpZvbfpP0PdunXL8tifSTIkGd9//7217fTp04arq6vRoUMHa1tm73dW58yqtg8//NCQZJw6dcowDMOIiYkxnJ2djZYtWxqpqanWfnPmzDEkGYsWLbK2pf9uLlmyxNqWmJho+Pv7G506dcrwWsA/GcsqAOQoFxcX9evXL0O7m5ub9f/fuHFDly9f1mOPPaaEhAQdOXLkruft0qWLihcvbn3+2GOPSbp9E9rdhIWF2cy+1ahRQ56entaxqamp2rJli9q3b6+AgABrvwoVKmR7Rm3ixIlatmyZateurU2bNunVV19VSEiIHnnkER0+fNjab9WqVapataqqVKmiy5cvWx/NmjWTJG3fvj1br/dXcXFxKlas2D2NTffnP6Nr164pNjZWjz32mKKioqzt3t7ekm4vk0lLS8v0PN7e3vr9998zLHvJCR4eHpJu/wxlxsvLS5K0adMmJSQk3PPrvPDCC9nuGxoaqpCQEOvz0qVLq127dtq0aVOGZUM5acuWLUpKStLLL79sczPic889J09PT3355Zc2/T08PGzWcjs7O6tu3brZ+h0C/kkIxwBy1IMPPihnZ+cM7YcOHVKHDh3k5eUlT09P+fr6Wv+iTl8LeielS5e2eZ4elK9du2b32PTx6WNjYmJ08+ZNVahQIUO/zNqy0q1bN+3atUvXrl3T5s2b1b17dx04cEBPPvmkbt26Jen2ethDhw7J19fX5lGpUiVrLffC09Mzy8CYXRs2bFD9+vXl6uqqEiVKyNfXV/Pnz7f58+nSpYsaNmyoZ599Vn5+furatas+/fRTm6A8evRoeXh4qG7duqpYsaIGDRpks+zi7/jjjz8kKct/CJQrV07Dhw/X//73P5UsWVLh4eGaO3dutn7G/nqe7KpYsWKGtkqVKikhIUGXLl2y63Xtcfr0aUlS5cqVbdqdnZ318MMPW4+ne+ihhzKsmf7z7wGA2wjHAHLUn2cf012/fl1NmjTRjz/+qEmTJmn9+vWKiIiw7p6Q1Qzkn2V1l76Rjd0o/87Ye+Hp6akWLVrok08+UZ8+ffTrr79qz549km5fa3BwsCIiIjJ9/Otf/7qn16xSpYpiY2N19uzZexq/a9cuPfXUU3J1ddW8efP01VdfKSIiQt27d7d5n9zc3LRz505t2bJFvXr10sGDB9WlSxe1aNHCOktatWpVHT16VCtWrFCjRo20Zs0aNWrUSBMmTLin2v7s559/VqlSpeTp6Zlln5kzZ+rgwYMaN26cbt68qSFDhqh69er6/fffs/06mf0c/x1Z3ciXmzPLf5XXvwdAYUU4BpDrduzYoStXrmjx4sUaOnSonnjiCYWFhdksk8hPpUqVkqurq06cOJHhWGZt9qhTp44k6cKFC5Ju31x19epVNW/eXGFhYRkef54FtGcv2yeffFJSxv2os2vNmjVydXXVpk2b1L9/f7Vu3VphYWGZ9nVwcFDz5s01a9Ys/fLLL5o8ebK2bdtmsySkaNGi6tKliz788EOdOXNGbdu21eTJk60z6PciMjJSv/76q1q2bHnXvsHBwXrttde0c+dO7dq1S+fOndOCBQusx3Nyn+Djx49naDt27Jjc3d2tN3QWL148ww4SkjLM7tpTW5kyZSRJR48etWlPSkrSqVOnrMcB2IdwDCDXpc9Y/XmGKikpSfPmzcuvkmw4OjoqLCxM69ats/kWuRMnTuj//b//d9fxCQkJioyMzPRY+vj00PvMM8/o3Llz+uCDDzL0vXnzpuLj463PixYtmmmgyszTTz+t4OBgTZ48OdNabty4oVdffTXL8Y6OjrJYLDYzmb/99luGb2q7evVqhrG1atWSJOtWdFeuXLE57uzsrGrVqskwDCUnJ2frev7q9OnT6tu3r5ydnTVy5Mgs+8XFxSklJcWmLTg4WA4ODjZb5dnz3t5NZGSkzbrss2fP6vPPP1fLli2tP/vly5dXbGysDh48aO134cIFffbZZxnOl93awsLC5OzsrNmzZ9v8bi1cuFCxsbHWHUYA2Iet3ADkugYNGqh48eLq06ePhgwZIovFoqVLlxao/5z7xhtvaPPmzWrYsKFefPFFpaamas6cOQoKCtIPP/xwx7EJCQlq0KCB6tevr1atWikwMFDXr1/XunXrtGvXLrVv3161a9eWdHurtU8//VQvvPCCtm/froYNGyo1NVVHjhzRp59+qk2bNllnm0NCQrRlyxbNmjVLAQEBKleunOrVq5dpDU5OTlq7dq3CwsLUuHFjPfPMM2rYsKGcnJx06NAhLVu2TMWLF89yr+O2bdtq1qxZatWqlbp3766YmBjNnTtXFSpUsAl0kyZN0s6dO9W2bVuVKVNGMTExmjdvnh566CHrfsAtW7aUv7+/GjZsKD8/Px0+fFhz5sxR27Zts3XTYFRUlD7++GOlpaXp+vXr2rdvn9asWWP9ualRo0aWY7dt26aXXnpJnTt3VqVKlZSSkqKlS5fK0dFRnTp1svaz5729m6CgIIWHh9ts5SbdvkkzXdeuXTV69Gh16NBBQ4YMUUJCgubPn69KlSrZBGt7avP19dXYsWM1ceJEtWrVSk899ZSOHj2qefPm6dFHH73rF/QAyEL+bZQBoDDLaiu3rLbw2r17t1G/fn3Dzc3NCAgIMEaNGmVs2rTJZhsuw8h6K7fMtveSZEyYMMH6PKuttgYNGpRhbJkyZTJsl7V161ajdu3ahrOzs1G+fHnjf//7nzFixAjD1dU1i3fhtuTkZOODDz4w2rdvb5QpU8ZwcXEx3N3djdq1axszZswwEhMTbfonJSUZ06ZNM6pXr264uLgYxYsXN0JCQoyJEydatygzDMM4cuSI0bhxY8PNzc2QlK1t3a5du2aMHz/eCA4ONtzd3Q1XV1cjKCjIGDt2rHHhwgVrv8y2Flu4cKFRsWJFw8XFxahSpYrx4YcfZnhPt27darRr184ICAgwnJ2djYCAAKNbt27GsWPHrH3++9//Go0bNzZ8fHwMFxcXo3z58sbIkSNtri0z6X/W6Y8iRYoYJUqUMOrVq2eMHTvWOH36dIYxf93K7eTJk0b//v2N8uXLG66urkaJEiWMxx9/3NiyZYvNuKze2/TrzWyrujv9fH388cfW96527do2P9PpNm/ebAQFBRnOzs5G5cqVjY8//jjTc2ZV21+3cks3Z84co0qVKoaTk5Ph5+dnvPjii8a1a9ds+mT1u5nVFnPAP5nFMArQ1A0AFDDt27fXoUOHMl1XCgC4/7DmGABMN2/etHl+/PhxffXVV2ratGn+FAQAyHPMHAOA6YEHHlDfvn2te8TOnz9fiYmJOnDgQKZ72QIA7j/ckAcAplatWmn58uWKjo6Wi4uLQkNDNWXKFIIxAPyDMHMMAAAAmFhzDAAAAJgIxwAAAICJNcc5IC0tTefPn1exYsVy9CtJAQAAkDMMw9CNGzcUEBAgB4es54cJxzng/PnzCgwMzO8yAAAAcBdnz57VQw89lOVxwnEOSP861LNnz8rT0zOfqwEAAMBfxcXFKTAw8K5fY084zgHpSyk8PT0JxwAAAAXY3ZbAckMeAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAiHAMAAAAmwjEAAABgIhwDAAAAJsIxAAAAYCIcAwAAACbCMQAAAGAqdOF47ty5Klu2rFxdXVWvXj3t3bv3jv1XrVqlKlWqyNXVVcHBwfrqq6+y7PvCCy/IYrHonXfeyeGqAQAAUBgUqnC8cuVKDR8+XBMmTFBUVJRq1qyp8PBwxcTEZNr/22+/Vbdu3TRgwAAdOHBA7du3V/v27fXzzz9n6PvZZ5/pu+++U0BAQG5fBgAAAAqoQhWOZ82apeeee079+vVTtWrVtGDBArm7u2vRokWZ9n/33XfVqlUrjRw5UlWrVtW///1vPfLII5ozZ45Nv3Pnzmnw4MH65JNP5OTklBeXAgAAgAKo0ITjpKQk7d+/X2FhYdY2BwcHhYWFKTIyMtMxkZGRNv0lKTw83KZ/WlqaevXqpZEjR6p69eq5UzwAAAAKhSL5XUB2Xb58WampqfLz87Np9/Pz05EjRzIdEx0dnWn/6Oho6/Np06apSJEiGjJkSLZrSUxMVGJiovV5XFxctscCAACg4Co0M8e5Yf/+/Xr33Xe1ePFiWSyWbI+bOnWqvLy8rI/AwMBcrBIAAAB5pdCE45IlS8rR0VEXL160ab948aL8/f0zHePv73/H/rt27VJMTIxKly6tIkWKqEiRIjp9+rRGjBihsmXLZlnL2LFjFRsba32cPXv2710cAAAACoRCE46dnZ0VEhKirVu3WtvS0tK0detWhYaGZjomNDTUpr8kRUREWPv36tVLBw8e1A8//GB9BAQEaOTIkdq0aVOWtbi4uMjT09PmAQAAgMKv0Kw5lqThw4erT58+qlOnjurWrat33nlH8fHx6tevnySpd+/eevDBBzV16lRJ0tChQ9WkSRPNnDlTbdu21YoVK/T999/r/ffflyT5+PjIx8fH5jWcnJzk7++vypUr5+3FAQAAIN8VqnDcpUsXXbp0SePHj1d0dLRq1aqljRs3Wm+6O3PmjBwc/m8yvEGDBlq2bJlee+01jRs3ThUrVtS6desUFBSUX5cAAACAAsxiGIaR30UUdnFxcfLy8lJsbCxLLAAAAAqg7Oa1QrPmGAAAAMhthGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyFLhzPnTtXZcuWlaurq+rVq6e9e/fesf+qVatUpUoVubq6Kjg4WF999ZX1WHJyskaPHq3g4GAVLVpUAQEB6t27t86fP5/blwEAAIACqFCF45UrV2r48OGaMGGCoqKiVLNmTYWHhysmJibT/t9++626deumAQMG6MCBA2rfvr3at2+vn3/+WZKUkJCgqKgovf7664qKitLatWt19OhRPfXUU3l5WQAAACggLIZhGPldRHbVq1dPjz76qObMmSNJSktLU2BgoAYPHqwxY8Zk6N+lSxfFx8drw4YN1rb69eurVq1aWrBgQaavsW/fPtWtW1enT59W6dKls1VXXFycvLy8FBsbK09Pz3u4MgAAAOSm7Oa1QjNznJSUpP379yssLMza5uDgoLCwMEVGRmY6JjIy0qa/JIWHh2fZX5JiY2NlsVjk7e2dI3UDAACg8CiS3wVk1+XLl5Wamio/Pz+bdj8/Px05ciTTMdHR0Zn2j46OzrT/rVu3NHr0aHXr1u2O/6JITExUYmKi9XlcXFx2LwMAAAAFWKGZOc5tycnJeuaZZ2QYhubPn3/HvlOnTpWXl5f1ERgYmEdVAgAAIDcVmnBcsmRJOTo66uLFizbtFy9elL+/f6Zj/P39s9U/PRifPn1aERERd103PHbsWMXGxlofZ8+evYcrAgAAQEFTaMKxs7OzQkJCtHXrVmtbWlqatm7dqtDQ0EzHhIaG2vSXpIiICJv+6cH4+PHj2rJli3x8fO5ai4uLizw9PW0eAAAAKPwKzZpjSRo+fLj69OmjOnXqqG7dunrnnXcUHx+vfv36SZJ69+6tBx98UFOnTpUkDR06VE2aNNHMmTPVtm1brVixQt9//73ef/99SbeD8dNPP62oqCht2LBBqamp1vXIJUqUkLOzc/5cKAAAAPJFoQrHXbp00aVLlzR+/HhFR0erVq1a2rhxo/WmuzNnzsjB4f8mwxs0aKBly5bptdde07hx41SxYkWtW7dOQUFBkqRz587piy++kCTVqlXL5rW2b9+upk2b5sl1AQAAoGAoVPscF1TscwwAAFCw3Xf7HAMAAAC5ze5w/NFHH+nLL7+0Ph81apS8vb3VoEEDnT59OkeLAwAAAPKS3eF4ypQpcnNzk3T7G+jmzp2r6dOnq2TJkho2bFiOFwgAAADkFbtvyDt79qwqVKggSVq3bp06deqkgQMHqmHDhtzABgAAgELN7pljDw8PXblyRZK0efNmtWjRQpLk6uqqmzdv5mx1AAAAQB6ye+a4RYsWevbZZ1W7dm0dO3ZMbdq0kSQdOnRIZcuWzen6AAAAgDxj98zx3LlzFRoaqkuXLmnNmjXWb5Tbv3+/unXrluMFAgAAAHmFfY5zAPscAwAAFGy5us/xrl271LNnTzVo0EDnzp2TJC1dulTffPPNvVULAAAAFAB2h+M1a9YoPDxcbm5uioqKUmJioiQpNjZWU6ZMyfECAQAAgLxidzj+z3/+owULFuiDDz6Qk5OTtb1hw4aKiorK0eIAAACAvGR3OD569KgaN26cod3Ly0vXr1/PiZoAAACAfGF3OPb399eJEycytH/zzTd6+OGHc6QoAAAAID/YHY6fe+45DR06VHv27JHFYtH58+f1ySef6JVXXtGLL76YGzUCAAAAecLuLwEZM2aM0tLS1Lx5cyUkJKhx48ZycXHRK6+8osGDB+dGjQAAAECeuOd9jpOSknTixAn98ccfqlatmjw8PHK6tkKDfY4BAAAKtuzmNbtnjtM5OzurWrVq9zocAAAAKHDsDscdOnSQxWLJ0G6xWOTq6qoKFSqoe/fuqly5co4UCAAAAOQVu2/I8/Ly0rZt2xQVFSWLxSKLxaIDBw5o27ZtSklJ0cqVK1WzZk3t3r07N+oFAAAAco3dM8f+/v7q3r275syZIweH29k6LS1NQ4cOVbFixbRixQq98MILGj16NF8nDQAAgELF7hvyfH19tXv3blWqVMmm/dixY2rQoIEuX76sn376SY899tg/5ktBuCEPAACgYMtuXrN7WUVKSoqOHDmSof3IkSNKTU2VJLm6uma6LhkAAAAoyOxeVtGrVy8NGDBA48aN06OPPipJ2rdvn6ZMmaLevXtLkr7++mtVr149ZysFAAAAcpnd4fjtt9+Wn5+fpk+frosXL0qS/Pz8NGzYMI0ePVqS1LJlS7Vq1SpnKwUAAABy2T1/CYh0e+2GpH/8OlvWHAMAABRsuf4lIBKhGAAAAPeXewrHq1ev1qeffqozZ84oKSnJ5lhUVFSOFAYAAADkNbt3q5g9e7b69esnPz8/HThwQHXr1pWPj49Onjyp1q1b50aNAAAAQJ6wOxzPmzdP77//vt577z05Oztr1KhRioiI0JAhQxQbG5sbNQIAAAB5wu5wfObMGTVo0ECS5Obmphs3bki6vcXb8uXLc7Y6AAAAIA/ZHY79/f119epVSVLp0qX13XffSZJOnTqlv7HxBQAAAJDv7A7HzZo10xdffCFJ6tevn4YNG6YWLVqoS5cu6tChQ44XCAAAAOQVu/c5TktLU1pamooUub3RxYoVK/Ttt9+qYsWKev755+Xs7JwrhRZk7HMMAABQsGU3r/2tLwHBbYRjAACAgi1XvwTk1q1bOnjwoGJiYpSWlmZz7KmnnrqXUwIAAAD5zu5wvHHjRvXu3VuXL1/OcMxisSg1NTVHCgMAAADymt035A0ePFidO3fWhQsXrOuP0x8EYwAAABRmdofjixcvavjw4fLz88uNegAAAIB8Y3c4fvrpp7Vjx45cKAUAAADIX3bvVpGQkKDOnTvL19dXwcHBcnJysjk+ZMiQHC2wMGC3CgAAgIIt13arWL58uTZv3ixXV1ft2LFDFovFesxisfwjwzEAAADuD3aH41dffVUTJ07UmDFj5OBg96oMAAAAoMCyO90mJSWpS5cuBGMAAADcd+xOuH369NHKlStzoxYAAAAgX9m9rCI1NVXTp0/Xpk2bVKNGjQw35M2aNSvHigMAAADykt3h+KefflLt2rUlST///LPNsT/fnAcAAAAUNnaH4+3bt+dGHQAAAEC+4646AAAAwJTtmeOOHTtmq9/atWvvuRgAAAAgP2U7HHt5eeVmHQAAAEC+y3Y4/vDDD3OzDgAAACDfseYYAAAAMBGOAQAAABPhGAAAADARjgEAAABTtsLxI488omvXrkmSJk2apISEhFwtCgAAAMgP2QrHhw8fVnx8vCRp4sSJ+uOPP3K1KAAAACA/ZGsrt1q1aqlfv35q1KiRDMPQW2+9JQ8Pj0z7jh8/PkcLBAAAAPKKxTAM426djh49qgkTJujXX39VVFSUqlWrpiJFMuZqi8WiqKioXCm0IIuLi5OXl5diY2Pl6emZ3+UAAADgL7Kb17K1rKJy5cpasWKF9u3bJ8MwtHXrVh04cCDDIy+C8dy5c1W2bFm5urqqXr162rt37x37r1q1SlWqVJGrq6uCg4P11Vdf2Rw3DEPjx4/XAw88IDc3N4WFhen48eO5eQkAAAAooOzerSItLU2lSpXKjVruauXKlRo+fLgmTJigqKgo1axZU+Hh4YqJicm0/7fffqtu3bppwIABOnDggNq3b6/27dvr559/tvaZPn26Zs+erQULFmjPnj0qWrSowsPDdevWrby6LAAAABQQ2VpW8Ve//vqr3nnnHR0+fFiSVK1aNQ0dOlTly5fP8QL/rF69enr00Uc1Z84cSbeDemBgoAYPHqwxY8Zk6N+lSxfFx8drw4YN1rb69eurVq1aWrBggQzDUEBAgEaMGKFXXnlFkhQbGys/Pz8tXrxYXbt2zVZdLKsAAAAo2HJ0WcWfbdq0SdWqVdPevXtVo0YN1ahRQ3v27FH16tUVERHxt4q+k6SkJO3fv19hYWHWNgcHB4WFhSkyMjLTMZGRkTb9JSk8PNza/9SpU4qOjrbp4+XlpXr16mV5TgAAANy/srVbxZ+NGTNGw4YN05tvvpmhffTo0WrRokWOFfdnly9fVmpqqvz8/Gza/fz8dOTIkUzHREdHZ9o/Ojraejy9Las+mUlMTFRiYqL1eVxcXPYvBAAAAAWW3TPHhw8f1oABAzK09+/fX7/88kuOFFXQTZ06VV5eXtZHYGBgfpcEAACAHGB3OPb19dUPP/yQof2HH37I1Rv1SpYsKUdHR128eNGm/eLFi/L39890jL+//x37p/+vPeeUpLFjxyo2Ntb6OHv2rN3XAwAAgILH7nD83HPPaeDAgZo2bZp27dqlXbt26c0339Tzzz+v5557LjdqlCQ5OzsrJCREW7dutbalpaVp69atCg0NzXRMaGioTX9JioiIsPYvV66c/P39bfrExcVpz549WZ5TklxcXOTp6WnzAAAAQOFn95rj119/XcWKFdPMmTM1duxYSVJAQIDeeOMNDRkyJMcL/LPhw4erT58+qlOnjurWrat33nlH8fHx6tevnySpd+/eevDBBzV16lRJ0tChQ9WkSRPNnDlTbdu21YoVK/T999/r/fffl3T7S0tefvll/ec//1HFihVVrlw5vf766woICFD79u1z9VoAAABQ8Ngdji0Wi4YNG6Zhw4bpxo0bkqRixYrleGGZ6dKliy5duqTx48crOjpatWrV0saNG6031J05c0YODv83Gd6gQQMtW7ZMr732msaNG6eKFStq3bp1CgoKsvYZNWqU4uPjNXDgQF2/fl2NGjXSxo0b5erqmifXBAAAgILjnvY5hi32OQYAACjYcm2fYwAAAOB+RTgGAAAATIRjAAAAwGRXOE5OTlbz5s11/Pjx3KoHAAAAyDd2hWMnJycdPHgwt2oBAAAA8pXdyyp69uyphQsX5kYtAAAAQL6ye5/jlJQULVq0SFu2bFFISIiKFi1qc3zWrFk5VhwAAACQl+wOxz///LMeeeQRSdKxY8dsjlkslpypCgAAAMgHdofj7du350YdAAAAQL67563cTpw4oU2bNunmzZuSJL5oDwAAAIWd3eH4ypUrat68uSpVqqQ2bdrowoULkqQBAwZoxIgROV4gAAAAkFfsDsfDhg2Tk5OTzpw5I3d3d2t7ly5dtHHjxhwtDgAAAMhLdq853rx5szZt2qSHHnrIpr1ixYo6ffp0jhUGAAAA5DW7Z47j4+NtZozTXb16VS4uLjlSFAAAAJAf7A7Hjz32mJYsWWJ9brFYlJaWpunTp+vxxx/P0eIAAACAvGT3sorp06erefPm+v7775WUlKRRo0bp0KFDunr1qnbv3p0bNQIAAAB5wu6Z46CgIB07dkyNGjVSu3btFB8fr44dO+rAgQMqX758btQIAAAA5AmLwQbFf1tcXJy8vLwUGxsrT0/P/C4HAAAAf5HdvGb3sgpJunbtmhYuXKjDhw9LkqpVq6Z+/fqpRIkS91YtAAAAUADYvaxi586dKlu2rGbPnq1r167p2rVrmj17tsqVK6edO3fmRo0AAABAnrB7WUVwcLBCQ0M1f/58OTo6SpJSU1P1r3/9S99++61++umnXCm0IGNZBQAAQMGW3bxm98zxiRMnNGLECGswliRHR0cNHz5cJ06cuLdqAQAAgALA7nD8yCOPWNca/9nhw4dVs2bNHCkKAAAAyA/ZuiHv4MGD1v8/ZMgQDR06VCdOnFD9+vUlSd99953mzp2rN998M3eqBAAAAPJAttYcOzg4yGKx6G5dLRaLUlNTc6y4woI1xwAAAAVbjm7ldurUqRwrDAAAACioshWOy5Qpk9t1AAAAAPnunr4E5Pz58/rmm28UExOjtLQ0m2NDhgzJkcIAAACAvGZ3OF68eLGef/55OTs7y8fHRxaLxXrMYrEQjgEAAFBo2f0lIIGBgXrhhRc0duxYOTjYvRPcfYkb8gAAAAq2XPsSkISEBHXt2pVgDAAAgPuO3Ql3wIABWrVqVW7UAgAAAOQru5dVpKam6oknntDNmzcVHBwsJycnm+OzZs3K0QILA5ZVAAAAFGw5us/xn02dOlWbNm1S5cqVJSnDDXkAAABAYWV3OJ45c6YWLVqkvn375kI5AAAAQP6xe82xi4uLGjZsmBu1AAAAAPnK7nA8dOhQvffee7lRCwAAAJCv7F5WsXfvXm3btk0bNmxQ9erVM9yQt3bt2hwrDgAAAMhLdodjb29vdezYMTdqAQAAAPKV3eH4ww8/zI06AAAAgHzH19wBAAAAJrtnjsuVK3fH/YxPnjz5twoCAAAA8ovd4fjll1+2eZ6cnKwDBw5o48aNGjlyZE7VBQAAAOQ5u8Px0KFDM22fO3euvv/++79dEAAAAJBfcmzNcevWrbVmzZqcOh0AAACQ53IsHK9evVolSpTIqdMBAAAAec7uZRW1a9e2uSHPMAxFR0fr0qVLmjdvXo4WBwAAAOQlu8Nx+/btbZ47ODjI19dXTZs2VZUqVXKqLgAAACDPWQzDMPK7iMIuLi5OXl5eio2NlaenZ36XAwAAgL/Ibl7jS0AAAAAAU7aXVTg4ONzxyz8kyWKxKCUl5W8XBQAAAOSHbIfjzz77LMtjkZGRmj17ttLS0nKkKAAAACA/ZDsct2vXLkPb0aNHNWbMGK1fv149evTQpEmTcrQ4AAAAIC/d05rj8+fP67nnnlNwcLBSUlL0ww8/6KOPPlKZMmVyuj4AAAAgz9gVjmNjYzV69GhVqFBBhw4d0tatW7V+/XoFBQXlVn0AAABAnsn2sorp06dr2rRp8vf31/LlyzNdZgEAAAAUZtne59jBwUFubm4KCwuTo6Njlv3Wrl2bY8UVFuxzDAAAULBlN69le+a4d+/ed93KDQAAACjMsh2OFy9enItlAAAAAPmv0HxD3tWrV9WjRw95enrK29tbAwYM0B9//HHHMbdu3dKgQYPk4+MjDw8PderUSRcvXrQe//HHH9WtWzcFBgbKzc1NVatW1bvvvpvblwIAAIACqtCE4x49eujQoUOKiIjQhg0btHPnTg0cOPCOY4YNG6b169dr1apV+vrrr3X+/Hl17NjRenz//v0qVaqUPv74Yx06dEivvvqqxo4dqzlz5uT25QAAAKAAyvYNefnp8OHDqlatmvbt26c6depIkjZu3Kg2bdro999/V0BAQIYxsbGx8vX11bJly/T0009Lko4cOaKqVasqMjJS9evXz/S1Bg0apMOHD2vbtm3Zro8b8gAAAAq27Oa1QjFzHBkZKW9vb2swlqSwsDA5ODhoz549mY7Zv3+/kpOTFRYWZm2rUqWKSpcurcjIyCxfKzY2ViVKlMi54gEAAFBoZPuGvPwUHR2tUqVK2bQVKVJEJUqUUHR0dJZjnJ2d5e3tbdPu5+eX5Zhvv/1WK1eu1JdffnnHehITE5WYmGh9HhcXl42rAAAAQEGXrzPHY8aMkcViuePjyJEjeVLLzz//rHbt2mnChAlq2bLlHftOnTpVXl5e1kdgYGCe1AgAAIDcla8zxyNGjFDfvn3v2Ofhhx+Wv7+/YmJibNpTUlJ09epV+fv7ZzrO399fSUlJun79us3s8cWLFzOM+eWXX9S8eXMNHDhQr7322l3rHjt2rIYPH259HhcXR0AGAAC4D+RrOPb19ZWvr+9d+4WGhur69evav3+/QkJCJEnbtm1TWlqa6tWrl+mYkJAQOTk5aevWrerUqZMk6ejRozpz5oxCQ0Ot/Q4dOqRmzZqpT58+mjx5crbqdnFxkYuLS7b6AgAAoPAoFLtVSFLr1q118eJFLViwQMnJyerXr5/q1KmjZcuWSZLOnTun5s2ba8mSJapbt64k6cUXX9RXX32lxYsXy9PTU4MHD5Z0e22xdHspRbNmzRQeHq4ZM2ZYX8vR0TFboT0du1UAAAAUbDn+9dH57ZNPPtFLL72k5s2by8HBQZ06ddLs2bOtx5OTk3X06FElJCRY295++21r38TERIWHh2vevHnW46tXr9alS5f08ccf6+OPP7a2lylTRr/99lueXBcAAAAKjkIzc1yQMXMMAABQsN1X+xwDAAAAeYFwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAqdCE46tXr6pHjx7y9PSUt7e3BgwYoD/++OOOY27duqVBgwbJx8dHHh4e6tSpky5evJhp3ytXruihhx6SxWLR9evXc+EKAAAAUNAVmnDco0cPHTp0SBEREdqwYYN27typgQMH3nHMsGHDtH79eq1atUpff/21zp8/r44dO2bad8CAAapRo0ZulA4AAIBCwmIYhpHfRdzN4cOHVa1aNe3bt0916tSRJG3cuFFt2rTR77//roCAgAxjYmNj5evrq2XLlunpp5+WJB05ckRVq1ZVZGSk6tevb+07f/58rVy5UuPHj1fz5s117do1eXt7Z7u+uLg4eXl5KTY2Vp6enn/vYgEAAJDjspvXCsXMcWRkpLy9va3BWJLCwsLk4OCgPXv2ZDpm//79Sk5OVlhYmLWtSpUqKl26tCIjI61tv/zyiyZNmqQlS5bIwaFQvB0AAADIJUXyu4DsiI6OVqlSpWzaihQpohIlSig6OjrLMc7OzhlmgP38/KxjEhMT1a1bN82YMUOlS5fWyZMns1VPYmKiEhMTrc/j4uLsuBoAAAAUVPk6VTpmzBhZLJY7Po4cOZJrrz927FhVrVpVPXv2tGvc1KlT5eXlZX0EBgbmUoUAAADIS/k6czxixAj17dv3jn0efvhh+fv7KyYmxqY9JSVFV69elb+/f6bj/P39lZSUpOvXr9vMHl+8eNE6Ztu2bfrpp5+0evVqSVL68uuSJUvq1Vdf1cSJEzM999ixYzV8+HDr87i4OAIyAADAfSBfw7Gvr698fX3v2i80NFTXr1/X/v37FRISIul2sE1LS1O9evUyHRMSEiInJydt3bpVnTp1kiQdPXpUZ86cUWhoqCRpzZo1unnzpnXMvn371L9/f+3atUvly5fPsh4XFxe5uLhk+zoBAABQOBSKNcdVq1ZVq1at9Nxzz2nBggVKTk7WSy+9pK5du1p3qjh37pyaN2+uJUuWqG7duvLy8tKAAQM0fPhwlShRQp6enho8eLBCQ0OtO1X8NQBfvnzZ+nr27FYBAACA+0OhCMeS9Mknn+ill15S8+bN5eDgoE6dOmn27NnW48nJyTp69KgSEhKsbW+//ba1b2JiosLDwzVv3rz8KB8AAACFQKHY57igY59jAACAgu2+2ucYAAAAyAuEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMhGMAAADARDgGAAAATIRjAAAAwEQ4BgAAAEyEYwAAAMBEOAYAAABMRfK7gPuBYRiSpLi4uHyuBAAAAJlJz2npuS0rhOMccOPGDUlSYGBgPlcCAACAO7lx44a8vLyyPG4x7hafcVdpaWk6f/68ihUrJovFkt/l4D4WFxenwMBAnT17Vp6envldDgD8bXyuIa8YhqEbN24oICBADg5Zryxm5jgHODg46KGHHsrvMvAP4unpyV8iAO4rfK4hL9xpxjgdN+QBAAAAJsIxAAAAYCIcA4WIi4uLJkyYIBcXl/wuBQByBJ9rKGi4IQ8AAAAwMXMMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAz8DX379pXFYtGbb75p075u3Tqbb0tMTU3V22+/reDgYLm6uqp48eJq3bq1du/ebTNu8eLFslgsslgscnBw0AMPPKAuXbrozJkzNv2aNm2a6etKUtu2bWWxWPTGG29kOLZ8+XI5Ojpq0KBBGY7t2LFDFotF169ft+MdAFDQpX9OWSwWOTs7q0KFCpo0aZJSUlKsv/fVq1dXamqqzThvb28tXrzY+rxs2bLW8/z5kf45dKfPkLJly+qdd96xPk8f+91339n0S0xMlI+PjywWi3bs2GFzbMOGDWrSpImKFSsmd3d3Pfroozb1SdJvv/0mi8WiUqVK6caNGzbHatWqZfO52LRpU7388ssZar3T5yT+GQjHwN/k6uqqadOm6dq1a5keNwxDXbt21aRJkzR06FAdPnxYO3bsUGBgoJo2bap169bZ9Pf09NSFCxd07tw5rVmzRkePHlXnzp0znDcwMDDDXwznzp3T1q1b9cADD2Ray8KFCzVq1CgtX75ct27duqfrBVD4tGrVShcuXNDx48c1YsQIvfHGG5oxY4b1+MmTJ7VkyZK7nmfSpEm6cOGCzWPw4MH3VFNgYKA+/PBDm7bPPvtMHh4eGfq+9957ateunRo2bKg9e/bo4MGD6tq1q1544QW98sorGfrfuHFDb7311j3VxeckCMfA3xQWFiZ/f39NnTo10+OffvqpVq9erSVLlujZZ59VuXLlVLNmTb3//vt66qmn9Oyzzyo+Pt7a32KxyN/fXw888IAaNGigAQMGaO/evYqLi7M57xNPPKHLly/bzD5/9NFHatmypUqVKpWhjlOnTunbb7/VmDFjVKlSJa1duzaH3gEABZ2Li4v8/f1VpkwZvfjiiwoLC9MXX3xhPT548GBNmDBBiYmJdzxPsWLF5O/vb/MoWrToPdXUp08frVixQjdv3rS2LVq0SH369LHpd/bsWY0YMUIvv/yypkyZomrVqqlChQoaMWKEZsyYoZkzZ2rPnj02YwYPHqxZs2YpJibGrpr4nIREOAb+NkdHR02ZMkXvvfeefv/99wzHly1bpkqVKunJJ5/McGzEiBG6cuWKIiIiMj13TEyMPvvsMzk6OsrR0dHmmLOzs3r06GEz87J48WL1798/03N9+OGHatu2rby8vNSzZ08tXLjQnssEcB9xc3NTUlKS9fnLL7+slJQUvffee3lWQ0hIiMqWLas1a9ZIks6cOaOdO3eqV69eNv1Wr16t5OTkTGeIn3/+eXl4eGj58uU27d26dbMuH7EHn5OQCMdAjujQoYNq1aqlCRMmZDh27NgxVa1aNdNx6e3Hjh2ztsXGxsrDw0NFixaVn5+ftm/frkGDBmU6O9O/f399+umnio+P186dOxUbG6snnngiQ7+0tDQtXrxYPXv2lCR17dpV33zzjU6dOnVP1wugcDIMQ1u2bNGmTZvUrFkza7u7u7smTJigqVOnKjY2Nsvxo0ePloeHh81j165d91xP//79tWjRIkm3/3Hfpk0b+fr62vQ5duyYvLy8Ml0u5uzsrIcfftjmM1SSdS30+++/r19//TVbtfA5iXSEYyCHTJs2TR999JEOHz6c4Zg9X0RZrFgx/fDDD/r+++81c+ZMPfLII5o8eXKmfWvWrKmKFStq9erVWrRokXr16qUiRYpk6BcREaH4+Hi1adNGklSyZEm1aNHC+pcSgPvbhg0b5OHhIVdXV7Vu3VpdunTJcNPugAED5OPjo2nTpmV5npEjR+qHH36wedSpU+ee6+rZs6ciIyN18uTJO/6Xr3sRHh6uRo0a6fXXX89Wfz4nkS7j36IA7knjxo0VHh6usWPHqm/fvtb2SpUqZRqYJVnbK1WqZG1zcHBQhQoVJN2eWf7111/14osvaunSpZmeo3///po7d65++eUX7d27N9M+Cxcu1NWrV+Xm5mZtS0tL08GDBzVx4kQ5OPDvZOB+9vjjj2v+/PlydnZWQEBApv+ILlKkiCZPnqy+ffvqpZdeyvQ8JUuWtH4+/ZWnp6ek2//1y9vb2+bY9evX5eXllWGMj4+PnnjiCQ0YMEC3bt1S69atM+wyUalSJcXGxur8+fMKCAiwOZaUlKRff/1Vjz/+eKY1vfnmmwoNDdXIkSMzPf5nfE4iHX/SQA568803tX79ekVGRlrbunbtquPHj2v9+vUZ+s+cOVM+Pj5q0aJFluccM2aMVq5cqaioqEyPd+/eXT/99JOCgoJUrVq1DMevXLmizz//XCtWrLCZ7Tlw4ICuXbumzZs338OVAihMihYtqgoVKqh06dKZBuN0nTt3VvXq1TVx4kS7X6NixYpycHDQ/v37bdpPnjyp2NhYm0mAP+vfv7927Nih3r17Z7i3QpI6deokJycnzZw5M8OxBQsWKD4+Xt26dcv03HXr1lXHjh01ZsyYO9bO5yT+jJljIAcFBwerR48emj17trWta9euWrVqlfr06aMZM2aoefPmiouL09y5c/XFF19o1apVd7zbOzAwUB06dND48eO1YcOGDMeLFy+uCxcuyMnJKdPxS5culY+Pj5555hmbvZclqU2bNlq4cKFatWplbfvpp59UrFgx63OLxaKaNWtm+z0AULi9+eabCg8Pz/TYjRs3FB0dbdPm7u4uT09PFStWTM8++6xGjBihIkWKKDg4WGfPntXo0aNVv359NWjQINNztmrVSpcuXbLOPP9V6dKlNX36dI0YMUKurq7q1auXnJyc9Pnnn2vcuHEaMWKE6tWrl+X1TJ48WdWrV7/jPwrs/ZzE/Y2ZYyCHTZo0SWlpadbnFotFn376qcaNG6e3335blStX1mOPPabTp09rx44dat++/V3POWzYMH355ZdZLpvw9vbOMmAvWrRIHTp0yPCBL92ekfniiy90+fJla1vjxo1Vu3Zt6yMkJOSu9QG4fzRr1kzNmjVTSkpKhmPjx4/XAw88YPMYNWqU9fi7776rPn36aPTo0apevbr69u2rGjVqaP369Zl+Bkm3PyNLliwpZ2fnLGt6+eWX9dlnn2nXrl2qU6eOgoKCtGzZMs2fP/+u+xlXqlRJ/fv3v+OexfZ+TuL+ZjHsuVMIAAAAuI8xcwwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAICJcAwAAACYCMcAAACAiXAMAAAAmAjHAAAAgIlwDAAAAJgIxwAAAIDp/wPDevKZsfmZIAAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -147,10 +176,25 @@
         "plt.show()"
       ],
       "metadata": {
-        "id": "nsVvU76ZShRH"
+        "id": "nsVvU76ZShRH",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "81a18f7a-0311-4529-cc94-e5bd7cec6ac8"
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1200x600 with 0 Axes>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -185,10 +229,121 @@
         "print(\"- Channels: 1 (Grayscale images saved as 3-channel RGB in format, need to be converted to grayscale during training)\")"
       ],
       "metadata": {
-        "id": "KG8OL77ZSmED"
+        "id": "KG8OL77ZSmED",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 228
+        },
+        "outputId": "ef7b7da5-b8b4-4c87-f65b-f41234ad5390"
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Dimension Stats (based on 200 samples):\n"
+          ]
+        },
+        {
+          "output_type": "error",
+          "ename": "ValueError",
+          "evalue": "min() iterable argument is empty",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+            "\u001b[0;32m/tmp/ipykernel_1976/3498276646.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Dimension Stats (based on {sample_size*2} samples):\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 15\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"- Min Dimensions: {min(widths)}x{min(heights)}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     16\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"- Max Dimensions: {max(widths)}x{max(heights)}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"- Avg Dimensions: {int(np.mean(widths))}x{int(np.mean(heights))}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mValueError\u001b[0m: min() iterable argument is empty"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 5. Pixel Intensity Distribution\n",
+        "\n",
+        "This section analyzes the grayscale pixel intensity distribution of chest X-ray images to better understand brightness, contrast variation, and preprocessing needs before model training."
+      ],
+      "metadata": {
+        "id": "EPJyC61fBOb-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "\n",
+        "pixel_values = []\n",
+        "sample_size = 100  # sample images from each class\n",
+        "\n",
+        "for cls in classes:\n",
+        "    path = os.path.join(data_dir, 'train', cls)\n",
+        "\n",
+        "    if os.path.exists(path):\n",
+        "        images = sorted(os.listdir(path))[:sample_size]\n",
+        "\n",
+        "        for img_name in images:\n",
+        "            img_path = os.path.join(path, img_name)\n",
+        "            img = cv2.imread(img_path, cv2.IMREAD_GRAYSCALE)\n",
+        "\n",
+        "            if img is not None:\n",
+        "                pixel_values.extend(img.flatten())\n",
+        "\n",
+        "pixel_values = np.array(pixel_values)\n",
+        "\n",
+        "if pixel_values.size == 0:\n",
+        "    print(\"No pixel data could be loaded.\")\n",
+        "    print(\"Check that the dataset exists under data/raw/chest_xray/\")\n",
+        "    print(\"and that train/NORMAL and train/PNEUMONIA contain images.\")\n",
+        "else:\n",
+        "    print(\"Pixel Intensity Statistics:\")\n",
+        "    print(f\"Mean Intensity: {np.mean(pixel_values):.2f}\")\n",
+        "    print(f\"Standard Deviation: {np.std(pixel_values):.2f}\")\n",
+        "    print(f\"Min Intensity: {np.min(pixel_values)}\")\n",
+        "    print(f\"Max Intensity: {np.max(pixel_values)}\")\n",
+        "\n",
+        "    plt.figure(figsize=(10, 6))\n",
+        "    plt.hist(pixel_values, bins=50)\n",
+        "    plt.title(\"Pixel Intensity Distribution\")\n",
+        "    plt.xlabel(\"Pixel Intensity (0 = Black, 255 = White)\")\n",
+        "    plt.ylabel(\"Frequency\")\n",
+        "    plt.grid(True)\n",
+        "    plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ytOvUhWmBRtk",
+        "outputId": "b645a8a4-496b-4490-c93b-89efa82e6da1"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "No pixel data could be loaded.\n",
+            "Check that the dataset exists under data/raw/chest_xray/\n",
+            "and that train/NORMAL and train/PNEUMONIA contain images.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Observations\n",
+        "\n",
+        "When the dataset is available locally, this section produces a grayscale histogram and summary statistics that help assess brightness and contrast variation across chest X-ray images.\n",
+        "\n",
+        "These findings can support preprocessing decisions such as normalization and may also help identify whether contrast-aware augmentation should be considered later.\n",
+        "\n",
+        "If no dataset is present in the current environment, the notebook reports the missing path instead of failing with an exception."
+      ],
+      "metadata": {
+        "id": "woVWHVB7DWXW"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Summary
Adds a pixel intensity distribution section to the EDA notebook, including grayscale histogram logic, summary statistics, and explanatory markdown.

## Changes Made
- Added a dedicated pixel intensity distribution section
- Added grayscale intensity summary statistics
- Added a histogram plot for pixel values when data is available
- Added safe handling for missing local dataset paths to prevent notebook crashes
- Added written notes connecting the output to preprocessing decisions

## Why
This addresses issue #35 and improves the notebook by documenting pixel intensity analysis while keeping execution robust when the dataset is not available in the current environment.

Closes #35