### PR TITLE
Add initial model config and align it with baseline model selection

### DIFF
--- a/configs/model/base.yaml
+++ b/configs/model/base.yaml
@@ -1,0 +1,12 @@
+name: "efficientnet_b0"
+library: "timm"
+pretrained: true
+num_classes: 1
+input_channels: 3
+image_size: [224, 224]
+pooling: "avg"
+dropout_rate: 0.0
+freeze_backbone: false
+head_type: "linear"
+checkpoint_path: null
+notes: "Placeholder base model config for binary pneumonia classification using timm."


### PR DESCRIPTION
# Pull Request

## Summary
Adds an initial placeholder `configs/model/base.yaml` file with expected model-related keys and example values aligned with the baseline model selection plan.

## Changes Made
- Added `configs/model/base.yaml`
- Included model name, library, pretrained flag, number of classes, input channels, image size, pooling, dropout, freeze setting, head type, and checkpoint path
- Used `efficientnet_b0` as the example baseline model value based on the documented comparison plan

## Why
This establishes the initial model configuration placeholder required before training code is written and keeps the config design consistent with the documented baseline model selection strategy.

Closes #40
Closes #48