### PR TITLE
Document candidate architectures for baseline model comparison

### DIFF
--- a/configs/model/base.yaml
+++ b/configs/model/base.yaml
@@ -1,8 +1,6 @@
-name: "efficientnet_b0"
+name: "tf_efficientnetv2_s"
 library: "timm"
 pretrained: true
-pretrained_weights: "imagenet"
-pretrained_source: "timm"
 num_classes: 1
 input_channels: 3
 image_size: [224, 224]
@@ -11,4 +9,4 @@ dropout_rate: 0.0
 freeze_backbone: false
 head_type: "linear"
 checkpoint_path: null
-notes: "Placeholder base model config for binary pneumonia classification using timm."
+notes: "Placeholder base model config for binary pneumonia classification using timm. EfficientNetV2-S is selected as the recommended starting model, with EfficientNet-B0 as a fallback if Colab memory or runtime becomes an issue."

--- a/docs/issues/04_baseline_model_selection.md
+++ b/docs/issues/04_baseline_model_selection.md
@@ -10,6 +10,55 @@ Define which pretrained model architectures will be compared during the modeling
 ## Background
 The project plans to use transfer learning with EfficientNet or ResNet architectures via the `timm` library. Before training, the candidate architectures and selection criteria should be agreed upon. This issue produces a documented model comparison plan rather than implementing training.
 
+## Candidate Architectures
+
+### 1. EfficientNet-B0
+
+**Rationale:**  
+EfficientNet-B0 is selected as a strong starting baseline because it offers a good balance between performance and computational efficiency. It has relatively low parameter count compared to larger CNN architectures while maintaining strong ImageNet transfer learning performance.
+
+**Pros:**
+- Lower memory usage, suitable for Google Colab T4 GPU
+- Strong pretrained performance on medical imaging transfer tasks
+- Faster training compared to larger models
+- Available directly in `timm`
+
+**Cons:**
+- Slightly more complex architecture than ResNet
+- May be less interpretable for debugging compared to simpler models
+
+
+### 2. ResNet-18
+
+**Rationale:**  
+ResNet-18 is included as a lightweight and simple baseline architecture. It is widely used, easy to debug, and provides a strong reference point for transfer learning experiments.
+
+**Pros:**
+- Very lightweight and fast to train
+- Excellent compatibility with limited GPU memory
+- Simple architecture and easier debugging
+- Strong baseline for comparison
+
+**Cons:**
+- Lower representational capacity than deeper models
+- May underperform compared to EfficientNet on more complex datasets
+
+
+### 3. ResNet-50
+
+**Rationale:**  
+ResNet-50 is included as a stronger but heavier ResNet baseline. It allows comparison between lightweight and deeper residual architectures.
+
+**Pros:**
+- Higher capacity than ResNet-18
+- Strong transfer learning performance
+- Well-established architecture in medical imaging research
+
+**Cons:**
+- Higher memory consumption
+- Slower training in Colab environments
+- Greater risk of overfitting on limited datasets
+
 ## Deliverables
 - [ ] List of candidate architectures with rationale (e.g., EfficientNet-B0, ResNet-50, ResNet-18)
 - [ ] Selection criteria documented (e.g., ROC AUC, sensitivity, parameter count, Colab memory fit)

--- a/docs/issues/04_baseline_model_selection.md
+++ b/docs/issues/04_baseline_model_selection.md
@@ -15,49 +15,137 @@ The project plans to use transfer learning with EfficientNet or ResNet architect
 ### 1. EfficientNet-B0
 
 **Rationale:**  
-EfficientNet-B0 is selected as a strong starting baseline because it offers a good balance between performance and computational efficiency. It has relatively low parameter count compared to larger CNN architectures while maintaining strong ImageNet transfer learning performance.
+EfficientNet-B0 is included as a strong lightweight baseline because it offers a good balance between performance and computational efficiency. It has a relatively low parameter count compared with larger CNN architectures while maintaining strong ImageNet transfer learning performance.
 
 **Pros:**
 - Lower memory usage, suitable for Google Colab T4 GPU
-- Strong pretrained performance on medical imaging transfer tasks
-- Faster training compared to larger models
+- Strong efficiency-to-performance balance
+- Faster training compared with larger models
 - Available directly in `timm`
 
 **Cons:**
-- Slightly more complex architecture than ResNet
-- May be less interpretable for debugging compared to simpler models
-
+- Lower capacity than newer EfficientNetV2 variants
+- Slightly more complex than ResNet for debugging
+- May underperform compared with newer architectures on difficult visual patterns
 
 ### 2. ResNet-18
 
 **Rationale:**  
-ResNet-18 is included as a lightweight and simple baseline architecture. It is widely used, easy to debug, and provides a strong reference point for transfer learning experiments.
+ResNet-18 is included as a lightweight classical CNN baseline. It is widely used, easy to debug, and provides a simple reference point for transfer learning experiments.
 
 **Pros:**
 - Very lightweight and fast to train
 - Excellent compatibility with limited GPU memory
-- Simple architecture and easier debugging
-- Strong baseline for comparison
+- Simple architecture and easy debugging
+- Useful baseline for comparison
 
 **Cons:**
-- Lower representational capacity than deeper models
-- May underperform compared to EfficientNet on more complex datasets
-
+- Lower representational capacity than deeper or newer models
+- May underperform compared with EfficientNet and ConvNeXt models
+- Less efficient accuracy scaling compared with newer architectures
 
 ### 3. ResNet-50
 
 **Rationale:**  
-ResNet-50 is included as a stronger but heavier ResNet baseline. It allows comparison between lightweight and deeper residual architectures.
+ResNet-50 is included as a stronger residual network baseline. It allows comparison between lightweight and deeper ResNet architectures.
 
 **Pros:**
 - Higher capacity than ResNet-18
 - Strong transfer learning performance
 - Well-established architecture in medical imaging research
+- Available directly in `timm`
 
 **Cons:**
-- Higher memory consumption
+- Higher memory consumption than ResNet-18 and EfficientNet-B0
 - Slower training in Colab environments
 - Greater risk of overfitting on limited datasets
+
+### 4. EfficientNetV2-S
+
+**Rationale:**  
+EfficientNetV2-S is included as a newer EfficientNet-family model designed to improve training efficiency and performance compared with earlier EfficientNet variants. It is a strong candidate when the project needs a balance between accuracy, parameter efficiency, and practical Colab training constraints.
+
+**Pros:**
+- Newer and more efficient than the original EfficientNet family
+- Strong transfer learning candidate for image classification
+- Better representational capacity than very small baselines
+- Available through `timm`
+
+**Cons:**
+- Heavier than EfficientNet-B0
+- May require more GPU memory and longer training time
+- Needs validation on the project dataset before final adoption
+
+### 5. ConvNeXt-Tiny
+
+**Rationale:**  
+ConvNeXt-Tiny is included as a modern CNN architecture that updates traditional convolutional networks using design ideas inspired by transformer-era models. It provides a useful comparison against both ResNet and EfficientNet models.
+
+**Pros:**
+- More modern architecture than ResNet
+- Strong image classification performance
+- Compatible with `timm`
+- Useful comparison point between classic CNNs and transformer-style models
+
+**Cons:**
+- More computationally demanding than lightweight baselines
+- May be unnecessary if EfficientNetV2-S provides similar performance with lower cost
+- Needs memory testing in Colab before being selected
+
+### 6. ViT-B/16
+
+**Rationale:**  
+ViT-B/16 is included as a transformer-based candidate architecture. It provides a different modeling approach from CNN-based architectures and can help determine whether transformer-style visual representations are useful for this dataset.
+
+**Pros:**
+- Modern transformer-based architecture
+- Strong transfer learning performance on many image classification tasks
+- Available through `timm`
+- Useful as a comparison against CNN-based models
+
+**Cons:**
+- Usually requires more data and compute than lightweight CNNs
+- May be less efficient in a limited Colab GPU environment
+- Could overfit if the dataset size and validation split are insufficient
+
+## Candidate Architecture Comparison
+
+| Model | Model Type | Relative Size | Expected Compute Cost | Colab Suitability | Main Role |
+|---|---|---:|---:|---:|---|
+| ResNet-18 | Classical CNN | Low | Low | High | Simple lightweight baseline |
+| ResNet-50 | Classical CNN | Medium | Medium | Medium | Stronger ResNet baseline |
+| EfficientNet-B0 | Efficient CNN | Low | Low-Medium | High | Efficient fallback baseline |
+| EfficientNetV2-S | Efficient CNN | Medium | Medium | Medium-High | Recommended starting model |
+| ConvNeXt-Tiny | Modern CNN | Medium | Medium-High | Medium | Modern CNN comparison |
+| ViT-B/16 | Vision Transformer | High | High | Low-Medium | Transformer-based comparison |
+
+## Selection Metrics
+
+The candidate architectures should later be compared using metrics suitable for imbalanced binary classification:
+
+- Average Precision / PR AUC
+- ROC AUC
+- Sensitivity / Recall for the pneumonia class
+- Precision
+- F1-score
+- Parameter count
+- Colab GPU memory usage
+- Training time and inference time
+
+Because this project is a binary classification task rather than an object detection task, Average Precision / PR AUC is more appropriate than object-detection mAP. However, Average Precision provides a similar ranking-focused view of model performance under class imbalance.
+
+## Selected Starting Model
+
+### EfficientNetV2-S
+
+EfficientNetV2-S is selected as the recommended starting model for the first baseline experiment.
+
+**Reasoning:**
+- It is newer than EfficientNet-B0 and designed for improved training efficiency.
+- It offers a strong balance between performance and computational cost.
+- It is available through `timm` with pretrained ImageNet weights.
+- It should provide stronger representational capacity than ResNet-18 while being more efficient than heavier alternatives.
+- It is more practical for limited GPU environments than larger transformer-based models such as ViT-B/16.
 
 ## Deliverables
 - [ ] List of candidate architectures with rationale (e.g., EfficientNet-B0, ResNet-50, ResNet-18)


### PR DESCRIPTION
# Pull Request

## Summary
Updates the baseline model comparison strategy by expanding the candidate architecture list, adding measurable selection criteria, and selecting a recommended starting model for the first baseline experiment.

## Changes Made
- Added EfficientNet-B0, ResNet-18, and ResNet-50 with rationale, pros, and cons
- Added newer `timm`-supported candidates: EfficientNetV2-S, ConvNeXt-Tiny, and ViT-B/16
- Added a candidate architecture comparison table
- Added selection metrics including Average Precision / PR AUC, ROC AUC, recall, precision, F1-score, parameter count, Colab GPU memory usage, and runtime
- Selected EfficientNetV2-S as the recommended starting model
- Kept EfficientNet-B0 as the fallback option if Colab memory or runtime becomes an issue
- Updated `configs/model/base.yaml` to match the selected EfficientNetV2-S baseline

## Why
This satisfies the requirement for documenting candidate architectures before training begins and responds to reviewer feedback by including newer model options, measurable comparison criteria, and a selected baseline model.

Closes #50