### PR TITLE
Clarify decision threshold policy

### DIFF
--- a/docs/EVALUATION_PROTOCOL.md
+++ b/docs/EVALUATION_PROTOCOL.md
@@ -75,6 +75,8 @@ A threshold of 0.5 is the standard baseline for binary probabilistic classifiers
 ### Important Rule
 **The test set must not be used to optimize the threshold.**
 
+Any deviation from the default threshold of 0.5 must include a documented justification, the validation procedure used to select the new threshold, and the metric trade-off that motivated the change.
+
 If threshold adjustment is explored, it must be done using:
 - the validation split, or
 - a separately defined development procedure


### PR DESCRIPTION
# Pull Request

## Summary
Clarifies the decision threshold policy in `docs/EVALUATION_PROTOCOL.md`.

## Changes Made
- Confirmed the default decision threshold is 0.5
- Clarified that any deviation from 0.5 requires documented justification
- Clarified that threshold changes must be based on validation/development procedure, not the held-out test set

## Why
This satisfies the threshold policy requirement and helps prevent outcome bias during final model evaluation.

Closes #59